### PR TITLE
Allow use of unverified methods

### DIFF
--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -230,10 +230,7 @@ func (s *webSocketServer) readAllEvents(conn *conn, request profileRequest, prof
 				conn.send(eventResponse{Type: "not-supported", Link: event.Link})
 			}
 
-		case microformats.Unverified:
-			conn.send(eventResponse{Type: "unverified", Link: event.Link})
-
-		case microformats.Verified:
+		case microformats.Unverified, microformats.Verified:
 			if strategy, ok := s.strategies.IsAllowed(event.Link); ok {
 				query := url.Values{
 					"me":           {request.Me},
@@ -242,7 +239,12 @@ func (s *webSocketServer) readAllEvents(conn *conn, request profileRequest, prof
 					"redirect_uri": {request.RedirectURI},
 				}
 
-				conn.send(eventResponse{Type: "verified", Link: event.Link, Method: chooseCtxMethod{
+				typeName := "unverified"
+				if event.Type == microformats.Verified {
+					typeName = "verified"
+				}
+
+				conn.send(eventResponse{Type: typeName, Link: event.Link, Method: chooseCtxMethod{
 					Query:        query.Encode(),
 					StrategyName: strategy.Name(),
 					ProfileURL:   event.Link,

--- a/web/static/choose.js
+++ b/web/static/choose.js
@@ -32,7 +32,7 @@ refresh.onclick = function() {
 };
 
 const elements = {};
-let anyVerified = false;
+let anyListed = false;
 
 socket.onmessage = function (event) {
     const profile = JSON.parse(event.data);
@@ -50,7 +50,7 @@ socket.onmessage = function (event) {
         case 'pgp':
             const pgpEl = renderText(methods, profile.Link);
             toMethod(pgpEl, profile.Method);
-            anyVerified = true;
+            anyListed = true;
             break;
         case 'found':
             elements[profile.Link] = renderText(methods, profile.Link);
@@ -59,15 +59,16 @@ socket.onmessage = function (event) {
             toError(elements[profile.Link], 'unsupported');
             break;
         case 'unverified':
-            methods.removeChild(elements[profile.Link]);
+            elements[profile.Link] = toMethod(elements[profile.Link], profile.Method, true);
+            anyListed = true;
             break;
         case 'verified':
             elements[profile.Link] = toMethod(elements[profile.Link], profile.Method);
-            anyVerified = true;
+            anyListed = true;
             break;
         case 'done':
             loader.classList.add('hide');
-            if (!anyVerified) {
+            if (!anyListed) {
                 const errorText = document.createTextNode("Sorry, you aren't able to use any of the supported authentication providers.");
                 methods.classList.add('info');
                 methods.appendChild(errorText);
@@ -139,13 +140,14 @@ function toError(li, errorClass) {
     li.appendChild(errorText);
 }
 
-function toMethod(li, method) {
+function toMethod(li, method, unverified) {
     while (li.firstChild) {
         li.removeChild(li.firstChild);
     }
 
     const btn = document.createElement('a');
     btn.classList.add('btn');
+    if (unverified) { btn.classList.add('unverified'); }
     btn.href = '/auth/start?' + method.Query;
 
     const name = document.createElement('strong');

--- a/web/static/welcome.css
+++ b/web/static/welcome.css
@@ -400,6 +400,18 @@ a.btn:hover {
     border-color: rgba(42, 100, 151, .5);
 }
 
+a.btn.unverified {
+    background: rgba(169, 97, 54, .1);
+    border-color: rgba(169, 97, 54, .2);
+    color: rgb(169, 97, 54);
+}
+
+a.btn.unverified:hover {
+    background: rgba(151, 98, 42, .1);
+    border-color: rgba(151, 98, 42, .5);
+    color: rgb(151, 98, 42);
+}
+
 .center {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
As Twitter and Flickr no longer use `rel=me` on profile pages the sign-in methods have been reduced to GitHub and PGP, which is pretty weak. This change means they can be used again, and it should be the same "safety" as the profile URL is checked after the auth callback against an API call. The only issue this may cause is the annoying UX flow where you pick one of these options but haven't set them up correctly.

- should this be the way all of the strategies use, i.e. should the "guarantee" of methods be removed and the flow become `[enter profile URL] -> [get strategies from profile URL] -> [user picks] -> [check profile matches] -> [sign-in or send back to choose]`
- does this make the service less secure?